### PR TITLE
Fix #4 - inconsistent pop up message with actual behavior

### DIFF
--- a/index.html
+++ b/index.html
@@ -66,16 +66,16 @@
       fs.writeFile("/note", document.querySelector("#note").innerHTML, function(err) 
         {
         if (err) throw err;
-
-      if(document.querySelector("#note").innerHTML == ""||document.querySelector("#note").innerHTML == str||str.indexOf(document.querySelector("#note").innerHTML)>=0) 
+      else{
+        if(document.querySelector("#note").innerHTML == ""||document.querySelector("#note").innerHTML == str) 
       
         {
           alert("No data to be saved!");
-        document.querySelector("#note").innerHTML=str;
-        }
-
+          document.querySelector("#note").innerHTML=str;
+        } 
         else 
         alert("Data saved!");
+      }
       });
     }
 


### PR DESCRIPTION
I have removed condition to check if the string the user wants to save match partially with “Welcome to my notepad!”. The app now behave as below:

- If the string is empty, pop up message will say “No data to be saved”

- If the string is exact the same as “Welcome to my notepad!”, pop up message will say “No data to be saved” as well

- Any other cases, data will be saved and display as it is

In this case, even the page gets refreshed, the result will be consistent.